### PR TITLE
Update target paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,9 +216,11 @@ no_verify: $(TARGET).z64
 	$(V)$(PRINT) "$(GREEN)Build Complete!$(NO_COL)\n"
 
 extract:
+	$(V)python3 ver/splat/update_target_paths.py $(BASENAME).$(REGION).$(VERSION).yaml
 	$(SPLAT) ver/splat/$(BASENAME).$(REGION).$(VERSION).yaml
 
 extractall:
+	$(V)python3 ver/splat/update_target_paths.py
 	$(SPLAT) ver/splat/$(BASENAME).us.v1.yaml
 	$(SPLAT) ver/splat/$(BASENAME).pal.v1.yaml
 	$(SPLAT) ver/splat/$(BASENAME).jpn.v1.yaml

--- a/ver/splat/update_target_paths.py
+++ b/ver/splat/update_target_paths.py
@@ -68,8 +68,6 @@ def main():
     
     for filePath in yamlFilePaths:
         update_yaml_file(filePath)
-    
-    
 
 if __name__ == '__main__':
     main()

--- a/ver/splat/update_target_paths.py
+++ b/ver/splat/update_target_paths.py
@@ -1,0 +1,75 @@
+# The purpose of this script is to update the `target_path` field of `options` in the YAML config file,
+#     so that users can use any filename for their roms instead of having to name them `baserom.us.v1.z64` etc.
+#     The ROM file is detected from it's SHA1 hash.
+
+import os
+import argparse
+import yaml
+import hashlib
+
+CURRENT_DIR = os.path.dirname(__file__)
+
+def get_sha1_hash(directoryPath):
+    sha1 = hashlib.sha1()
+    with open(directoryPath, 'rb') as file:
+        while chunk := file.read(8192):
+            sha1.update(chunk)
+    return sha1.hexdigest()
+
+def get_all_files_from_directory(directoryPath):
+    return [os.path.join(directoryPath, f) for f in os.listdir(directoryPath) if os.path.isfile(os.path.join(directoryPath, f))]
+
+def get_files_with_extension(directoryPath, extension):
+    yaml_files = []
+    for root, dirs, files in os.walk(directoryPath):
+        for file in files:
+            if file.endswith(extension):
+                yaml_files.append(os.path.join(root, file))
+    return yaml_files
+
+def get_yaml_files(directoryPath):
+    return get_files_with_extension(directoryPath, '.yaml')
+    
+def update_yaml_file(yamlFilePath):
+    yamlData = yaml.safe_load(open(yamlFilePath, 'r'))
+    yamlOptions = yamlData['options']
+    yamlSha1 = yamlData['sha1']
+    basepath = os.path.join(CURRENT_DIR, yamlOptions['base_path']) # Not going to override base_path, so this should be fine.
+    target_path_dir = os.path.dirname(yamlOptions['target_path'])
+    target_path_basename = os.path.basename(yamlOptions['target_path'])
+    target_folder = os.path.join(basepath, target_path_dir)
+    target_folder_files = get_all_files_from_directory(target_folder)
+    newTargetPath = None
+    for file in target_folder_files:
+        if get_sha1_hash(file) == yamlSha1:
+            if os.path.basename(file) == target_path_basename:
+                #print('No need to update the name!')
+                return
+            # Name does NOT match, so need to update the yaml.
+            newTargetPath = os.path.relpath(file, start=basepath)
+            break
+    if newTargetPath == None:
+        return
+    yamlData['options']['target_path'] = newTargetPath
+    print('target_path in YAML config "' + yamlFilePath + '" was changed to "' + newTargetPath + '"')
+    yaml.dump(yamlData, open(yamlFilePath, 'w')) # Save the new change.
+
+def main():
+    parser = argparse.ArgumentParser(description='Updates the target_path option for the yaml files.') 
+    parser.add_argument('yamlFile', nargs='?', default='all', help='Optional file argument (default: "all")')
+    args = parser.parse_args()
+    
+    if args.yamlFile == "all":
+        yamlFilePaths = get_yaml_files(CURRENT_DIR)
+    else:
+        yamlFilePaths = [ os.path.join(CURRENT_DIR, args.yamlFile) ]
+        
+    print(yamlFilePaths)
+    
+    for filePath in yamlFilePaths:
+        update_yaml_file(filePath)
+    
+    
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Having the user set the rom names manually is a regression from the original repo. This script allows the user to have any name for their rom files, and this script will detect it from the SHA1 hash. If the rom's filename is different than what is in the YAML file, then the script will update the YAML file with the new filename.