### PR TITLE
Last idea was bad. This one is better.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,11 +216,11 @@ no_verify: $(TARGET).z64
 	$(V)$(PRINT) "$(GREEN)Build Complete!$(NO_COL)\n"
 
 extract:
-	$(V)python3 ver/splat/update_target_paths.py $(BASENAME).$(REGION).$(VERSION).yaml
+	$(V)python3 ver/splat/update_baserom_names.py $(BASENAME).$(REGION).$(VERSION).yaml
 	$(SPLAT) ver/splat/$(BASENAME).$(REGION).$(VERSION).yaml
 
 extractall:
-	$(V)python3 ver/splat/update_target_paths.py
+	$(V)python3 ver/splat/update_baserom_names.py
 	$(SPLAT) ver/splat/$(BASENAME).us.v1.yaml
 	$(SPLAT) ver/splat/$(BASENAME).pal.v1.yaml
 	$(SPLAT) ver/splat/$(BASENAME).jpn.v1.yaml

--- a/ver/splat/update_baserom_names.py
+++ b/ver/splat/update_baserom_names.py
@@ -38,21 +38,14 @@ def update_yaml_file(yamlFilePath):
     target_path_dir = os.path.dirname(yamlOptions['target_path'])
     target_path_basename = os.path.basename(yamlOptions['target_path'])
     target_folder = os.path.join(basepath, target_path_dir)
+    target_path_full = os.path.join(target_folder, target_path_basename)
     target_folder_files = get_all_files_from_directory(target_folder)
-    newTargetPath = None
     for file in target_folder_files:
         if get_sha1_hash(file) == yamlSha1:
-            if os.path.basename(file) == target_path_basename:
-                #print('No need to update the name!')
+            if os.path.basename(file) != target_path_basename:
+                print(f'Baserom file "{os.path.basename(file)}" renamed to "{target_path_basename}"')
+                os.rename(file, target_path_full) 
                 return
-            # Name does NOT match, so need to update the yaml.
-            newTargetPath = os.path.relpath(file, start=basepath)
-            break
-    if newTargetPath == None:
-        return
-    yamlData['options']['target_path'] = newTargetPath
-    print('target_path in YAML config "' + yamlFilePath + '" was changed to "' + newTargetPath + '"')
-    yaml.dump(yamlData, open(yamlFilePath, 'w')) # Save the new change.
 
 def main():
     parser = argparse.ArgumentParser(description='Updates the target_path option for the yaml files.') 
@@ -63,8 +56,6 @@ def main():
         yamlFilePaths = get_yaml_files(CURRENT_DIR)
     else:
         yamlFilePaths = [ os.path.join(CURRENT_DIR, args.yamlFile) ]
-        
-    print(yamlFilePaths)
     
     for filePath in yamlFilePaths:
         update_yaml_file(filePath)


### PR DESCRIPTION
Instead of updating the YAML files, the python script now updates the baserom names instead. Less annoying to the maintainers.